### PR TITLE
Update for new DockerEE version

### DIFF
--- a/multi-node/azuredeploy.json
+++ b/multi-node/azuredeploy.json
@@ -1007,7 +1007,7 @@
     },
     "dtr_Storage_Key": {
       "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('shared').storage.name), '2016-12-01').keys[0].value]"
+      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('shared').storage.name), '2016-01-01').keys[0].value]"
     }
   }
 }

--- a/multi-node/azuredeploy.json
+++ b/multi-node/azuredeploy.json
@@ -38,10 +38,13 @@
         "ucp": "latest",
         "dtr": "latest"
       }
+    },
+    "domainPrefix" : {
+      "type": "string"
     }
   },
   "variables": {
-    "labName": "[resourceGroup().name]",
+    "labName": "[parameters('domainPrefix')]",
     "shared": {
       "storage": {
         "name": "[concat('sa', uniqueString(resourceGroup().id))]",

--- a/multi-node/azuredeploy.json
+++ b/multi-node/azuredeploy.json
@@ -34,7 +34,7 @@
     "versions": {
       "type": "object",
       "defaultValue": {
-        "engine": "stable-17.06",
+        "engine": "stable-18.09",
         "ucp": "latest",
         "dtr": "latest"
       }

--- a/multi-node/azuredeploy.json
+++ b/multi-node/azuredeploy.json
@@ -98,13 +98,13 @@
       }
     },
     "api": {
-      "availabilitySets": "2015-06-15",
-      "loadBalancers": "2015-06-15",
-      "networkInterfaces": "2015-06-15",
-      "publicIPAddresses": "2015-06-15",
-      "storageAccounts": "2015-06-15",
-      "virtualMachines": "2015-06-15",
-      "virtualNetwork": "2015-06-15"
+      "availabilitySets": "2017-03-30",
+      "loadBalancers": "2017-10-01",
+      "networkInterfaces": "2017-10-01",
+      "publicIPAddresses": "2017-10-01",
+      "storageAccounts": "2016-01-01",
+      "virtualMachines": "2017-03-30",
+      "virtualNetwork": "2017-10-01"
     }
   },
   "resources": [{

--- a/multi-node/azuredeploy.json
+++ b/multi-node/azuredeploy.json
@@ -48,7 +48,7 @@
     "shared": {
       "storage": {
         "name": "[concat('sa', uniqueString(resourceGroup().id))]",
-        "type": "Standard_LRS",
+        "type": "Premium_LRS",
         "vhdContainerName": "vhd"
       },
       "networking": {

--- a/multi-node/azuredeploy.json
+++ b/multi-node/azuredeploy.json
@@ -145,6 +145,9 @@
       "tags": {
         "displayName": "Availability Set - Managers"
       },
+      "sku":{
+        "name": "Aligned"
+      },
       "properties": {
         "platformFaultDomainCount": 2,
         "platformUpdateDomainCount": 5
@@ -158,6 +161,9 @@
       "tags": {
         "displayName": "Availability Set - DTR"
       },
+      "sku":{
+        "name": "Aligned"
+      },
       "properties": {
         "platformFaultDomainCount": 2,
         "platformUpdateDomainCount": 5
@@ -170,6 +176,9 @@
       "location": "[resourceGroup().location]",
       "tags": {
         "displayName": "Availability Set - Workers (Linux)"
+      },
+      "sku":{
+        "name": "Aligned"
       },
       "properties": {
         "platformFaultDomainCount": 2,
@@ -714,12 +723,10 @@
         "storageProfile": {
           "imageReference": "[variables('managers').imageReference]",
           "osDisk": {
-            "name": "osdisk",
             "diskSizeGB": 128,
-            "vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('shared').storage.name), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, 'vhd', '/', 'manager-01', '-osdisk.vhd')]"
+            "managedDisk":{
+              "storageAccountType" : "Premium_LRS"
             },
-            "caching": "ReadWrite",
             "createOption": "FromImage"
           }
         },
@@ -787,12 +794,10 @@
         "storageProfile": {
           "imageReference": "[variables('managers').imageReference]",
           "osDisk": {
-            "name": "osdisk",
             "diskSizeGB": 128,
-            "vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('shared').storage.name), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, 'vhd', '/', concat('manager-', padLeft(copyIndex(2), 2, '0')), '-osdisk.vhd')]"
+            "managedDisk":{
+              "storageAccountType" : "Premium_LRS"
             },
-            "caching": "ReadWrite",
             "createOption": "FromImage"
           }
         },
@@ -861,12 +866,10 @@
         "storageProfile": {
           "imageReference": "[variables('dtr').imageReference]",
           "osDisk": {
-            "name": "osdisk",
             "diskSizeGB": 128,
-            "vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('shared').storage.name), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, 'vhd', '/', concat('dtr-', padLeft(copyIndex(1), 2, '0')), '-osdisk.vhd')]"
+            "managedDisk":{
+              "storageAccountType" : "Premium_LRS"
             },
-            "caching": "ReadWrite",
             "createOption": "FromImage"
           }
         },
@@ -936,12 +939,10 @@
         "storageProfile": {
           "imageReference": "[variables('workers-linux').imageReference]",
           "osDisk": {
-            "name": "osdisk",
             "diskSizeGB": 128,
-            "vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('shared').storage.name), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, 'vhd', '/', concat('worker-linux-', padLeft(copyIndex(1), 2, '0')), '-osdisk.vhd')]"
+            "managedDisk":{
+              "storageAccountType" : "Premium_LRS"
             },
-            "caching": "ReadWrite",
             "createOption": "FromImage"
           }
         },


### PR DESCRIPTION
The deployment of multi node DockerEE cluster fails because the latest version of UCP cannot be installed in version 17.06. So in this change set the version has been changed to the latest one 18.09.

The API version of the resource providers has changed and updated in the latest stack version. 

The domain name prefix for the public IP addresses has been disconnected from the resource group name to allow for capitals and other special characters.

VM disks have been replaced with Premium LRS, managed ones, to avoid having to manage storage account.